### PR TITLE
detect, unify: Add basic idea of how detect interacts with unify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ CFLAGS+=-D'CONFIG_GCC=y'
 endif
 
 SRC:=src/core.c
+SRC+=src/unify.c
 LIB:=lib/per_cpu.c
 
 OBJ=$(SRC:.c=.o)

--- a/include/ucsan/compiler.h
+++ b/include/ucsan/compiler.h
@@ -32,5 +32,6 @@
 #define __alias(symbol) __attribute__((__alias__(#symbol)))
 #define _RET_IP_ (unsigned long)__builtin_return_address(0)
 #define __always_inline inline __attribute__((__always_inline__))
+#define noinline __attribute__((__noinline__))
 
 #endif /* __COMPILER__ */

--- a/include/ucsan/ucsan.h
+++ b/include/ucsan/ucsan.h
@@ -1,0 +1,30 @@
+#ifndef __UCSAN_UCSAN_H__
+#define __UCSAN_UCSAN_H__
+
+#include <stdatomic.h>
+
+/* In Linux, the page size is 4096 bytes. */
+#define PAGE_SIZE 4096
+#define PAGE_SHIFT 12
+
+/*
+ * We first use the page size and address to get the slot of the address reside.
+ * Then search all the index of that slot to get the corresponding watchpoint.
+ * So the watchpoint data structure, will be like:
+ *
+ *			      NR_UCSAN_WP (generally is 4096 bytes size)
+ *	 		slot 1 [0, 1, 2]
+ * 	NR_UCSAN_SLOT	slot 2 [3, 4, 5]
+ *  			and so on...
+ *
+ * We use the following macro as:
+ * 	- src/core.c: atomic_long watchpoints[NR_UCSAN_SLOT * NR_UCSAN_WP];
+ *	- src/unify.c: struct cached_info cached_info[NR_UCSAN_SLOT * NR_UCSAN_WP];
+ *
+ * NOTE: The UCSAN_NR_WATCHPOINT is from config, we won't use it directly.
+ */
+#define NR_UCSAN_SLOT UCSAN_NR_WATCHPOINT
+#define NR_UCSAN_WP (PAGE_SIZE / sizeof(atomic_long))
+#define WP_SLOT(addr) ((addr >> PAGE_SHIFT) % NR_UCSAN_SLOT)
+
+#endif /* __UCSAN_UCSAN_H__ */

--- a/include/ucsan/unify.h
+++ b/include/ucsan/unify.h
@@ -1,0 +1,26 @@
+#ifndef __UCSAN_UNIFY_H__
+#define __UCSAN_UNIFY_H__
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct access_info {
+	const volatile void *ptr;
+	size_t size;
+	int access_type;
+	int task_pid;
+	int cpu_id;
+	unsigned long ip;
+};
+
+void unify_set_info(const volatile void *ptr, size_t size, int access_type,
+		     unsigned long ip, int watchpoint_idx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UCSAN_REPORT_H__ */

--- a/include/ucsan/unify.h
+++ b/include/ucsan/unify.h
@@ -2,6 +2,7 @@
 #define __UCSAN_UNIFY_H__
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,7 +18,10 @@ struct access_info {
 };
 
 void unify_set_info(const volatile void *ptr, size_t size, int access_type,
-		     unsigned long ip, int watchpoint_idx);
+		    unsigned long ip, int watchpoint_idx);
+void unify_report(const volatile void *ptr, size_t size, int type,
+		  unsigned long ip, unsigned long old, unsigned long new,
+		  bool changed);
 
 #ifdef __cplusplus
 }

--- a/src/unify.c
+++ b/src/unify.c
@@ -1,5 +1,6 @@
 #include <ucsan/unify.h>
 #include <ucsan/ucsan.h>
+#include <stdbool.h>
 
 // TODO: Should we use the cpp file?
 
@@ -28,7 +29,7 @@ static void unify_add_info(struct access_info *ai, struct cached_info *ci)
 }
 
 void unify_set_info(const volatile void *ptr, size_t size, int access_type,
-		     unsigned long ip, int watchpoint_idx)
+		    unsigned long ip, int watchpoint_idx)
 {
 	/* create access_info structure */
 	struct access_info ai = {
@@ -42,4 +43,11 @@ void unify_set_info(const volatile void *ptr, size_t size, int access_type,
 
 	/* Add to the structure */
 	unify_add_info(&ai, &cached_info[watchpoint_idx]);
+}
+
+// TODO: check the access type of each task
+void unify_report(const volatile void *ptr, size_t size, int type,
+		  unsigned long ip, unsigned long old, unsigned long new,
+		  bool changed)
+{
 }

--- a/src/unify.c
+++ b/src/unify.c
@@ -1,0 +1,45 @@
+#include <ucsan/unify.h>
+#include <ucsan/ucsan.h>
+
+// TODO: Should we use the cpp file?
+
+struct cached_info {
+	/* TODO: Add the data structure to handle mutiple items */
+	int dummy;
+};
+
+struct cached_info cached_info[NR_UCSAN_SLOT * NR_UCSAN_WP];
+
+// TODO: OS specific
+int task_pid(void)
+{
+	return 0;
+}
+
+// TODO: OS specific
+int smp_processor_id()
+{
+	return 0;
+}
+
+// TODO
+static void unify_add_info(struct access_info *ai, struct cached_info *ci)
+{
+}
+
+void unify_set_info(const volatile void *ptr, size_t size, int access_type,
+		     unsigned long ip, int watchpoint_idx)
+{
+	/* create access_info structure */
+	struct access_info ai = {
+		.ptr = ptr,
+		.size = size,
+		.access_type = access_type,
+		.task_pid = task_pid(),
+		.cpu_id = smp_processor_id(),
+		.ip = ip,
+	};
+
+	/* Add to the structure */
+	unify_add_info(&ai, &cached_info[watchpoint_idx]);
+}


### PR DESCRIPTION
The detect part will call report_set_info() to register the task
information when the watchpoint found out.
And, it will call the report function in detect::setup_watchpoint()
to summarize the data race information.

Also, complete the implementation of the detect subsystem.

Signed-off-by: Chih-En Lin <shiyn.lin@gmail.com>