### PR TITLE
detect: Fix miss use expected in atomic_cmp_xchg()

### DIFF
--- a/tests/printut.h
+++ b/tests/printut.h
@@ -28,18 +28,18 @@ static inline unsigned long __get_ms(void)
 
 #define __FILE_NAME__ __FILE__
 
-#define pr_err(fmt, ...)                                                  \
-	do {                                                              \
-		fprintf(stderr, " [%-10lu] ERROR: %s:%d:%s(): " fmt,      \
-			__get_ms(), __FILE_NAME__, __LINE__, __func__,    \
-			##__VA_ARGS__);                                   \
+#define pr_err(fmt, ...)                                               \
+	do {                                                           \
+		fprintf(stderr, " [%-10lu] ERROR: %s:%d:%s(): " fmt,   \
+			__get_ms(), __FILE_NAME__, __LINE__, __func__, \
+			##__VA_ARGS__);                                \
 	} while (0)
 
 #define pr_info(fmt, ...)                                                  \
 	do {                                                               \
 		unsigned long __ms = __get_ms();                           \
-		printf(" [%-10lu] %s:%d:%s(): " fmt, __ms,                 \
-		       __FILE_NAME__, __LINE__, __func__, ##__VA_ARGS__);  \
+		printf(" [%-10lu] %s:%d:%s(): " fmt, __ms, __FILE_NAME__,  \
+		       __LINE__, __func__, ##__VA_ARGS__);                 \
 		fprintf(stderr, " [%-10lu] INFO: %s+%d:%s(): " fmt, __ms,  \
 			__FILE_NAME__, __LINE__, __func__, ##__VA_ARGS__); \
 	} while (0)
@@ -57,11 +57,11 @@ static inline unsigned long __get_ms(void)
 
 #define BUG_ON(cond) _BUG_ON(cond, __stringlfy(cond))
 
-#define UNIT_BUG_ON(cond)                                           \
-	do {                                                        \
-		_BUG_ON(0 != (cond), __stringlfy(cond) " failed");  \
-		printf(" [TEST SUCCESS] %s\n", #cond);              \
-		fprintf(stderr, " [TEST SUCCESS] %s\n", #cond);     \
+#define UNIT_BUG_ON(cond)                                          \
+	do {                                                       \
+		_BUG_ON(0 != (cond), __stringlfy(cond) " failed"); \
+		printf(" [TEST SUCCESS] %s\n", #cond);             \
+		fprintf(stderr, " [TEST SUCCESS] %s\n", #cond);    \
 	} while (0)
 
 #endif /* __PRINT_UNIT_TEST_H__ */


### PR DESCRIPTION
When ptr is not equal to expected, ptr will write to expected.
It cannot reuse the expected value twice time in atomic_cmp_xchg().

Reported-by: ziyuan1135 <>
Signed-off-by: Chih-En Lin <shiyn.lin@gmail.com>

---

From:
* https://github.com/linD026/ucsan/issues/14
