### PR TITLE
detect: Change condition of data race

### DIFF
--- a/include/ucsan/encoding.h
+++ b/include/ucsan/encoding.h
@@ -11,15 +11,16 @@
  *
  *   - tasn read/write operation : 1 bit
  *   - object size		 : 5 bits for 1,2,4,8,16 size
- *   - consumed			 : 1 bit
  */
-#define WATCHPOINT_ADDR_MASK ((1UL << 56) - 1)
-#define WATCHPOINT_CONSUMED_MASK (1UL << 56)
-#define WATCHPOINT_SIZE_1 (1UL << 57)
-#define WATCHPOINT_SIZE_2 (1UL << 58)
-#define WATCHPOINT_SIZE_4 (1UL << 59)
-#define WATCHPOINT_SIZE_8 (1UL << 60)
-#define WATCHPOINT_SIZE_16 (1UL << 61)
-#define WATCHPOINT_WRITE_MASK (1UL << 62)
+#define WATCHPOINT_ADDR_MASK ((1UL << 57) - 1)
+#define WATCHPOINT_SIZE_1 (1UL << 58)
+#define WATCHPOINT_SIZE_2 (1UL << 59)
+#define WATCHPOINT_SIZE_4 (1UL << 60)
+#define WATCHPOINT_SIZE_8 (1UL << 61)
+#define WATCHPOINT_SIZE_16 (1UL << 62)
+#define WATCHPOINT_WRITE_MASK (1UL << 63)
+
+#define WATCHPOINT_CONSUMED 1UL
+#define WATCHPOINT_INVALID 0UL
 
 #endif /* __UCSAN_ENCODING_H__ */

--- a/include/ucsan/unify.h
+++ b/include/ucsan/unify.h
@@ -20,8 +20,8 @@ struct access_info {
 void unify_set_info(const volatile void *ptr, size_t size, int access_type,
 		    unsigned long ip, int watchpoint_idx);
 void unify_report(const volatile void *ptr, size_t size, int type,
-		  unsigned long ip, unsigned long old, unsigned long new,
-		  bool changed);
+		  unsigned long ip, unsigned long old_value,
+		  unsigned long new_value);
 
 #ifdef __cplusplus
 }

--- a/src/unify.c
+++ b/src/unify.c
@@ -47,7 +47,7 @@ void unify_set_info(const volatile void *ptr, size_t size, int access_type,
 
 // TODO: check the access type of each task
 void unify_report(const volatile void *ptr, size_t size, int type,
-		  unsigned long ip, unsigned long old, unsigned long new,
-		  bool changed)
+		  unsigned long ip, unsigned long old_value,
+		  unsigned long new_value)
 {
 }


### PR DESCRIPTION
Currently, the data race condition is to check the watchpoint is
modified. And send the watchpoint state to the unify subsystem. But the
unify subsystem cannot use this information to get the old value.

So, here we change the logic of how the data race detects. We compare
the value before and after the delay to determine whether the data race
occurs. And for this new logic, we also don't have to use the operation
type in the watchpoint state to see the data race happens (write/write,
write/read pairs).

Signed-off-by: Chih-En Lin <shiyn.lin@gmail.com>