### PR TITLE
unify: Add the basic implement of unify

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -103,3 +103,8 @@ SpacesInSquareBrackets: false
 Standard: Cpp03
 TabWidth: 8
 UseTab: Always
+
+ForEachMacros:
+  - 'list_for_each'
+  - 'list_for_each_from'
+  - 'list_for_each_safe'

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CFLAGS+=-Wall
 CFLAGS+=-O1
 # Position Independent Code suitable for use in a shared library.
 CFLAGS+=-fPIC
+CFLAGS+=-rdynamic
 CFLAGS+=-D'UCSAN_NR_CPU=$(nr_cpu)'
 CFLAGS+=-D'UCSAN_NR_WATCHPOINT'=$(nr_wp)
 
@@ -23,6 +24,7 @@ SRC:=src/core.c
 SRC+=src/unify.c
 LIB:=lib/per_cpu.c
 TEST:=tests/test_watchpoint.c
+TEST+=tests/test_unify.c
 
 OBJ=$(SRC:.c=.o)
 OBJ+=$(LIB:.c=.o)

--- a/include/ucsan/compiler.h
+++ b/include/ucsan/compiler.h
@@ -29,9 +29,20 @@
 	})
 #endif
 
+#ifndef __alias
 #define __alias(symbol) __attribute__((__alias__(#symbol)))
+#endif
+
+#ifndef _RET_IP__
 #define _RET_IP_ (unsigned long)__builtin_return_address(0)
+#endif
+
+#ifndef __always_inline
 #define __always_inline inline __attribute__((__always_inline__))
+#endif
+
+#ifndef noinline
 #define noinline __attribute__((__noinline__))
+#endif
 
 #endif /* __COMPILER__ */

--- a/include/ucsan/list.h
+++ b/include/ucsan/list.h
@@ -1,0 +1,56 @@
+#ifndef __LIST_H__
+#define __LIST_H__
+
+#include <stddef.h>
+
+struct list_head {
+	struct list_head *next;
+	struct list_head *prev;
+};
+
+static inline void list_init(struct list_head *node)
+{
+	node->next = node;
+	node->prev = node;
+}
+
+static inline void __list_add(struct list_head *new, struct list_head *prev,
+			      struct list_head *next)
+{
+	next->prev = new;
+	new->next = next;
+	new->prev = prev;
+	prev->next = new;
+}
+
+static inline void list_add(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head, head->next);
+}
+
+static inline void list_add_tail(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head->prev, head);
+}
+
+static inline void __list_del(struct list_head *prev, struct list_head *next)
+{
+	next->prev = prev;
+	prev->next = next;
+}
+
+static inline void list_del(struct list_head *node)
+{
+	__list_del(node->prev, node->next);
+	list_init(node);
+}
+
+#define list_for_each(n, head) for (n = (head)->next; n != (head); n = n->next)
+
+#define list_for_each_from(pos, head) for (; pos != (head); pos = pos->next)
+
+#define list_for_each_safe(pos, n, head)                       \
+	for (pos = (head)->next, n = pos->next; pos != (head); \
+	     pos = n, n = pos->next)
+
+#endif /* __LIST_H__ */

--- a/include/ucsan/report.h
+++ b/include/ucsan/report.h
@@ -1,19 +1,31 @@
 #ifndef __UCSAN_REPORT_H__
 #define __UCSAN_REPORT_H__
 
+#include <ucsan/compiler.h>
 #include <stdio.h>
 
-#define report_print(fmt, ...)                       \
-	do {                                         \
-		fprintf(stderr, fmt, ##__VA_ARGS__); \
+#define UCSAN_REPORT_FILE_NAME "ucsan_report.log"
+FILE *UCSAN_REPORT_FILE = NULL;
+
+/*
+ * To exclude the unit test detection, we use stdout to print the data race
+ * report.
+ */
+#define report_print(fmt, ...)                                          \
+	do {                                                            \
+		if (likely(UCSAN_REPORT_FILE))                          \
+			fprintf(UCSAN_REPORT_FILE, fmt, ##__VA_ARGS__); \
+		fprintf(stdout, fmt, ##__VA_ARGS__);                    \
 	} while (0)
 
-#define report_init() \
-	report_print( \
+#define report_init()                                           \
+	UCSAN_REPORT_FILE = fopen(UCSAN_REPORT_FILE_NAME, "w"); \
+	report_print(                                           \
 		"==================================================================\n");
 
-#define report_exit() \
-	report_print( \
-		"==================================================================\n");
+#define report_exit()                                                                    \
+	report_print(                                                                    \
+		"==================================================================\n"); \
+	fclose(UCSAN_REPORT_FILE);
 
 #endif /* __UCSAN_REPORT_H__ */

--- a/include/ucsan/report.h
+++ b/include/ucsan/report.h
@@ -1,0 +1,19 @@
+#ifndef __UCSAN_REPORT_H__
+#define __UCSAN_REPORT_H__
+
+#include <stdio.h>
+
+#define report_print(fmt, ...)                       \
+	do {                                         \
+		fprintf(stderr, fmt, ##__VA_ARGS__); \
+	} while (0)
+
+#define report_init() \
+	report_print( \
+		"==================================================================\n");
+
+#define report_exit() \
+	report_print( \
+		"==================================================================\n");
+
+#endif /* __UCSAN_REPORT_H__ */

--- a/include/ucsan/spinlock.h
+++ b/include/ucsan/spinlock.h
@@ -1,0 +1,46 @@
+#ifndef __UCSAN_SPINLOCK_H__
+#define __UCSAN_SPINLOCK_H__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+typedef pthread_mutex_t spinlock_t;
+
+#define DEFINE_SPINLOCK(lock) spinlock_t lock = PTHREAD_MUTEX_INITIALIZER
+#define SPINLOCK_INIT PTHREAD_MUTEX_INITIALIZER
+
+static __inline__ void spin_lock_init(spinlock_t *sp)
+{
+	int ret;
+
+	ret = pthread_mutex_init(sp, NULL);
+	if (ret != 0) {
+		fprintf(stderr, "spin_lock_init:pthread_mutex_init %d\n", ret);
+		abort();
+	}
+}
+
+static __inline__ void spin_lock(spinlock_t *sp)
+{
+	int ret;
+
+	ret = pthread_mutex_lock(sp);
+	if (ret != 0) {
+		fprintf(stderr, "spin_lock:pthread_mutex_lock %d\n", ret);
+		abort();
+	}
+}
+
+static __inline__ void spin_unlock(spinlock_t *sp)
+{
+	int ret;
+
+	ret = pthread_mutex_unlock(sp);
+	if (ret != 0) {
+		fprintf(stderr, "spin_unlock:pthread_mutex_unlock %d\n", ret);
+		abort();
+	}
+}
+
+#endif /* __UCSAN_SPINLOCK_H__ */

--- a/include/ucsan/ucsan.h
+++ b/include/ucsan/ucsan.h
@@ -32,6 +32,6 @@
 #define UCSAN_ACCESS_COMPOUND 0x2
 
 #define type_expect_write(type) \
-	(type == (UCSAN_ACCESS_WRITE | UCSAN_ACCESS_COMPOUND))
+	(type & (UCSAN_ACCESS_WRITE | UCSAN_ACCESS_COMPOUND))
 
 #endif /* __UCSAN_UCSAN_H__ */

--- a/include/unit_test.h
+++ b/include/unit_test.h
@@ -5,6 +5,8 @@
 
 #if defined(__UT_DETECT)
 #include "../tests/test_watchpoint.c"
+#elif defined(__UT_UNIFY)
+#include "../tests/test_unify.c"
 #endif
 
 #endif /* __UCSAN_UNIT_TEST_H__ */

--- a/src/unify.c
+++ b/src/unify.c
@@ -29,7 +29,7 @@ struct task_info *task_container[NR_UCSAN_SLOT * NR_UCSAN_WP] = { NULL };
 
 static __always_inline int task_pid(void)
 {
-	int pid = (int) getpid();
+	int pid = (int)getpid();
 	return pid;
 }
 
@@ -138,7 +138,7 @@ void unify_report(const volatile void *ptr, size_t size, int type,
 	report_print("%p / %p\n\n", (void *)ip, (void *)head_task->ip);
 
 #define report_task_print(task)                                               \
-	report_print("%s to 0x%px of %zu bytes by %d on cpu %d:\n",           \
+	report_print("%s to 0x%px of %zu bytes by task %d on cpu %d:\n",      \
 		     type_expect_write(task->access_type) ? "write" : "read", \
 		     task->ptr, task->size, task->pid, task->cpuid);          \
 	for (i = 0; i < task->nr_stack_info; i++)                             \

--- a/src/unify.c
+++ b/src/unify.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <ucsan/unify.h>
 #include <ucsan/report.h>
 #include <ucsan/ucsan.h>
@@ -6,6 +7,7 @@
 #include <ucsan/spinlock.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <execinfo.h>
 
 #define STACK_BUF_SIZE 16
@@ -25,14 +27,15 @@ struct task_info {
 static DEFINE_SPINLOCK(task_container_lock);
 struct task_info *task_container[NR_UCSAN_SLOT * NR_UCSAN_WP] = { NULL };
 
-int task_pid(void)
+static __always_inline int task_pid(void)
 {
-	return 0;
+	int pid = (int) getpid();
+	return pid;
 }
 
-int smp_processor_id()
+static __always_inline int smp_processor_id()
 {
-	return 0;
+	return sched_getcpu();
 }
 
 static __always_inline void collect_stack_info(char ***stack_info, int *nptrs)

--- a/src/unify.c
+++ b/src/unify.c
@@ -1,53 +1,153 @@
 #include <ucsan/unify.h>
+#include <ucsan/report.h>
 #include <ucsan/ucsan.h>
+#include <ucsan/compiler.h>
+#include <ucsan/list.h>
+#include <ucsan/spinlock.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <execinfo.h>
 
-// TODO: Should we use the cpp file?
+#define STACK_BUF_SIZE 16
 
-struct cached_info {
-	/* TODO: Add the data structure to handle mutiple items */
-	int dummy;
+struct task_info {
+	pid_t pid;
+	int cpuid;
+	int access_type; /* read:true(1), write:false(0) */
+	void *ptr; /* Address of data race object */
+	size_t size; /* size of object */
+	unsigned long ip;
+	char **stack_info;
+	int nr_stack_info; /* the number of string in stack_info */
+	struct list_head head; /* head of the data race task */
 };
 
-struct cached_info cached_info[NR_UCSAN_SLOT * NR_UCSAN_WP];
+static DEFINE_SPINLOCK(task_container_lock);
+struct task_info *task_container[NR_UCSAN_SLOT * NR_UCSAN_WP];
 
-// TODO: OS specific
 int task_pid(void)
 {
 	return 0;
 }
 
-// TODO: OS specific
 int smp_processor_id()
 {
 	return 0;
 }
 
-// TODO
-static void unify_add_info(struct access_info *ai, struct cached_info *ci)
+void collect_stack_info(char ***stack_info, int *nptrs)
 {
+	void *buf[STACK_BUF_SIZE];
+
+	*nptrs = backtrace(buf, STACK_BUF_SIZE);
+	*stack_info = backtrace_symbols(buf, *nptrs);
+}
+
+static int unify_task_container_producer(void *ptr, size_t size,
+					 int access_type, unsigned long ip)
+{
+	const unsigned long slot = WP_SLOT((unsigned long)ptr);
+	int i, ret = -1;
+	struct task_info **task_con_pos = NULL;
+	struct task_info *task = malloc(sizeof(struct task_info));
+	if (!task)
+		return -1;
+
+	task->pid = task_pid();
+	task->cpuid = smp_processor_id();
+	task->access_type = access_type;
+	task->ptr = ptr;
+	task->size = size;
+	task->ip = ip;
+	collect_stack_info(&task->stack_info, &task->nr_stack_info);
+	list_init(&task->head);
+
+	spin_lock(&task_container_lock);
+
+	for (i = 0; i < NR_UCSAN_WP; i++) {
+		task_con_pos = &task_container[slot + i];
+
+		if (!(*task_con_pos)) {
+			*task_con_pos = task;
+			ret = 0;
+			break;
+		} else if ((*task_con_pos)->ptr == task->ptr) {
+			// TODO: handle the range of object
+			list_add(&task->head, &(*task_con_pos)->head);
+			ret = 0;
+			break;
+		}
+	}
+
+	spin_unlock(&task_container_lock);
+	return ret;
+}
+
+static struct task_info *unify_task_conatainer_consumer(void *ptr, size_t size)
+{
+	const unsigned long slot = WP_SLOT((unsigned long)ptr);
+	int i;
+	struct task_info **task_con_pos = NULL;
+	struct task_info *task = NULL;
+
+	spin_lock(&task_container_lock);
+	for (i = 0; i < NR_UCSAN_WP; i++) {
+		task_con_pos = &task_container[slot + i];
+
+		if (!(*task_con_pos) && (*task_con_pos)->ptr == task->ptr &&
+		    (*task_con_pos)->size == task->size) {
+			task = *task_con_pos;
+			*task_con_pos = NULL;
+			break;
+		}
+	}
+	spin_unlock(&task_container_lock);
+	return task;
 }
 
 void unify_set_info(const volatile void *ptr, size_t size, int access_type,
 		    unsigned long ip, int watchpoint_idx)
 {
-	/* create access_info structure */
-	struct access_info ai = {
-		.ptr = ptr,
-		.size = size,
-		.access_type = access_type,
-		.task_pid = task_pid(),
-		.cpu_id = smp_processor_id(),
-		.ip = ip,
-	};
-
-	/* Add to the structure */
-	unify_add_info(&ai, &cached_info[watchpoint_idx]);
+	if (unify_task_container_producer((void *)ptr, size, access_type, ip))
+		printf("task container is Full\n");
 }
 
-// TODO: check the access type of each task
 void unify_report(const volatile void *ptr, size_t size, int type,
 		  unsigned long ip, unsigned long old_value,
 		  unsigned long new_value)
 {
+	int i;
+	struct list_head *tmp, *n;
+	struct task_info *task,
+		*head_task = unify_task_conatainer_consumer((void *)ptr, size);
+	if (!task) {
+		printf("unify report(): cannot find the task\n");
+		return;
+	}
+
+	report_init();
+
+	report_print("BUG: UCSAN: data-race in");
+	list_for_each (tmp, &head_task->head) {
+		task = container_of(tmp, struct task_info, head);
+		report_print(" %p ", (void *)task->ip);
+	}
+	report_print("\n\n");
+
+	list_for_each (tmp, &head_task->head) {
+		task = container_of(tmp, struct task_info, head);
+		report_print("%s to 0x%px of %zu bytes by %d on cpu %d:\n",
+			     type_expect_write(task->access_type) ? "write" :
+								    "read",
+			     task->ptr, task->size, task->pid, task->cpuid);
+
+		for (i = 0; i < task->nr_stack_info; i++)
+			report_print("  %s\n", task->stack_info[i]);
+		report_print("\n");
+	}
+
+	report_print("value changed: 0x%0lx -> 0x%0lx\n\n", old_value,
+		     new_value);
+
+	report_exit();
 }

--- a/tests/test_unify.c
+++ b/tests/test_unify.c
@@ -1,0 +1,133 @@
+#ifdef __UT_UNIFY
+#include <stdbool.h>
+#include <string.h>
+#include <ucsan/compiler.h>
+#include <ucsan/ucsan.h>
+#include <ucsan/report.h>
+
+#include "printut.h"
+
+#undef __FILE_NAME__
+#define __FILE_NAME__ "tests/test_unify.c"
+
+struct task_info;
+
+int test_producer_consumer(void)
+{
+	int ret = 0, foo = 0;
+	void *ptr = &foo;
+	size_t size = sizeof(__typeof__(foo));
+	int access_type = UCSAN_ACCESS_WRITE;
+	unsigned long ip = _RET_IP_;
+	struct task_info *task = NULL;
+
+	pr_info("ptr=%p size=%zu access_type=%x ip=%lx\n", ptr, size,
+		access_type, ip);
+
+	if (unify_task_container_producer(ptr, size, access_type, ip)) {
+		pr_err("task container producer\n");
+		ret = -1;
+	}
+
+	task = unify_task_conatainer_consumer(ptr, size);
+	if (!task) {
+		pr_err("task container consumer\n");
+		ret = -1;
+	}
+
+	if (task->ptr != ptr) {
+		pr_err("ptr not equal\n");
+		ret = -1;
+	}
+	if (task->size != size) {
+		pr_err("size not equal\n");
+		ret = -1;
+	}
+	if (task->access_type != access_type) {
+		pr_err("access_type not equal\n");
+		ret = -1;
+	}
+	if (task->ip != ip) {
+		pr_err("ip not equal\n");
+		ret = -1;
+	}
+
+	return ret;
+}
+
+struct report_check_table {
+	const char *substring;
+	bool found;
+};
+
+struct report_check_table report_check_table[] = {
+	[0] = { .substring = "BUG: UCSAN: data-race", .found = false },
+	[1] = { .substring = "write to", .found = false },
+	[2] = { .substring = "value changed:", .found = false },
+};
+static int nr_check_table = 3;
+
+int test_report(void)
+{
+	char *line = NULL;
+	size_t line_size = 0;
+	ssize_t nr_read;
+	int line_count = 0, check_count = 0, i, ret = 0, foo = 0;
+	void *ptr = &foo;
+	size_t size = sizeof(__typeof__(foo));
+	int access_type = UCSAN_ACCESS_WRITE;
+	unsigned long ip = _RET_IP_;
+
+	pr_info("ptr=%p size=%zu access_type=%x ip=%lx\n", ptr, size,
+		access_type, ip);
+
+	unify_set_info(ptr, size, access_type, ip, 0);
+	unify_report(ptr, size, access_type, ip, 0, 1);
+
+	UCSAN_REPORT_FILE = fopen(UCSAN_REPORT_FILE_NAME, "r");
+	if (!UCSAN_REPORT_FILE) {
+		pr_err("Doesn't create the %s\n", UCSAN_REPORT_FILE_NAME);
+		ret = -1;
+	}
+
+	while ((nr_read = getline(&line, &line_size, UCSAN_REPORT_FILE)) !=
+	       -1) {
+		line_count++;
+		if (nr_read <= 1)
+			continue;
+		line[nr_read - 1] = '\0';
+		pr_info("read line:%d: \"%s\"\n", line_count, line);
+		for (i = check_count; i < nr_check_table; i++) {
+			if (report_check_table[i].found)
+				continue;
+			if (strstr(line, report_check_table[i].substring) !=
+			    NULL) {
+				report_check_table[i].found = true;
+				check_count++;
+				break;
+			}
+		}
+		free(line);
+		line = NULL;
+	}
+
+	if (check_count != nr_check_table) {
+		for (i = 0; i < nr_check_table; i++) {
+			if (!report_check_table[i].found)
+				pr_err("\"%s\" not found\n",
+				       report_check_table[i].substring);
+		}
+		ret = -1;
+	}
+
+	return ret;
+}
+
+int main(void)
+{
+	UNIT_BUG_ON(test_producer_consumer());
+	UNIT_BUG_ON(test_report());
+
+	return 0;
+}
+#endif /* __UT_UNIFY */

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -90,6 +90,7 @@ function unify {
 
 		# Remove the generated file
 		rm -f report.log
+		rm -f ucsan_report.log
 		rm -f unify
 		print_unit_name "unify"
 		make -C $DIR clean quiet=1 --no-print-directory
@@ -100,6 +101,7 @@ function unify {
 
 	# Remove the generated file
 	rm -f unify.log
+	rm -f ucsan_report.log
 	rm -f unify
 	print_unit_name "unify"
 }

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -73,12 +73,45 @@ function detect {
 	print_unit_name "detect"
 }
 
+function unify {
+	# Print unit test name
+	print_unit_name "unify"
+
+	# Compile
+	local obj="$DIR/src/unify.o"
+	gcc -o unify $obj -fsanitize=thread -lpthread  -rdynamic
+
+	# Execute and pipe the stderr to log file
+	./unify 2> unify.log
+
+	# Check " ERROR:" string and the count
+	report_log "unify subsystem" unify.log
+	if [[ $? -eq 1 ]]; then
+
+		# Remove the generated file
+		rm -f report.log
+		rm -f unify
+		print_unit_name "unify"
+		make -C $DIR clean quiet=1 --no-print-directory
+
+		# exit 1 will general errors
+		exit 1
+	fi
+
+	# Remove the generated file
+	rm -f unify.log
+	rm -f unify
+	print_unit_name "unify"
+}
+
+
 make -C $DIR all quiet=1 test=1 --no-print-directory
 echo ""
 echo " ------------------------------ unit test start ------------------------------ "
 
 # unit test function call here
 detect
+unify
 
 echo " ------------------------------ unit test end -------------------------------- "
 echo ""


### PR DESCRIPTION
The report log will be like this:

    ==================================================================
    BUG: UCSAN: data-race in 0x5622807d9500 / 0x5622807d9500
    
    write to 0x0x7fff15e1e02cx of 4 bytes by 219483 on cpu 9:
      /lib/x86_64-linux-gnu/libtsan.so.0(backtrace+0xfb) [0x7f27800a63eb]
      ./unify(unify_report+0x1cc) [0x5622807d8835]
      ./unify(test_report+0x11b) [0x5622807d91f1]
      ./unify(main+0x6e) [0x5622807d9500]
      /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7f277fe75083]
      ./unify(_start+0x2e) [0x5622807d82ee]
    
    write to 0x0x7fff15e1e02cx of 4 bytes by 219483 on cpu 9:
      /lib/x86_64-linux-gnu/libtsan.so.0(backtrace+0xfb) [0x7f27800a63eb]
      ./unify(+0x1515) [0x5622807d8515]
      ./unify(unify_set_info+0xd) [0x5622807d8652]
      ./unify(test_report+0xfa) [0x5622807d91d0]
      ./unify(main+0x6e) [0x5622807d9500]
      /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7f277fe75083]
      ./unify(_start+0x2e) [0x5622807d82ee]
    
    value changed: 0x0 -> 0x1
    
    ==================================================================

Also, add the unit test of unify.
